### PR TITLE
MODCXMUX-31-update-merge-and-sort 

### DIFF
--- a/src/main/java/org/folio/codex/CodexInterfaces.java
+++ b/src/main/java/org/folio/codex/CodexInterfaces.java
@@ -1,15 +1,23 @@
 package org.folio.codex;
 
+
 public enum CodexInterfaces {
-  CODEX("codex"), CODEX_PACKAGES("codex-packages");
+  CODEX("codex", "/codex-instances?"), CODEX_PACKAGES("codex-packages", "/codex-packages?");
 
   private String value;
 
-  CodexInterfaces(String value) {
+  private String queryPath;
+
+  CodexInterfaces(String value, String queryPath) {
     this.value = value;
+    this.queryPath = queryPath;
   }
 
   public String getValue() {
     return value;
+  }
+
+  public String getQueryPath() {
+    return queryPath;
   }
 }

--- a/src/main/java/org/folio/codex/InstanceComparator.java
+++ b/src/main/java/org/folio/codex/InstanceComparator.java
@@ -14,11 +14,10 @@ public class InstanceComparator {
     throw new IllegalStateException("InstanceComparator");
   }
 
-  private static int cmp(String i1, String i2, boolean fReverse) {
+  private static int cmp(String i1, String i2) {
     final String s1 = i1 != null ? i1 : "";
     final String s2 = i2 != null ? i2 : "";
-    final int r = s1.compareToIgnoreCase(s2);
-    return fReverse ? -r : r;
+    return s1.compareToIgnoreCase(s2);
   }
 
   static Comparator<Instance> get(CQLSortNode sn) {
@@ -29,29 +28,28 @@ public class InstanceComparator {
     Iterator<ModifierSet> it = sn.getSortIndexes().iterator();
     if (it.hasNext()) {
       ModifierSet s = it.next();
-      List<Modifier> mods = s.getModifiers();
-      boolean reverse = false;
-      for (Modifier mod : mods) {
-        if (mod.getType().startsWith("desc")) {
-          reverse = true;
-        }
-      }
-      final boolean fReverse = reverse;
       final String index = s.getBase();
 
       if ("title".equals(index)) {
         comp = (Instance i1, Instance i2)
-          -> cmp(i1.getTitle(), i2.getTitle(), fReverse);
+          -> cmp(i1.getTitle(), i2.getTitle());
       } else if ("date".equals(index)) {
         comp = (Instance i1, Instance i2)
-          -> cmp(i1.getDate(), i2.getDate(), fReverse);
+          -> cmp(i1.getDate(), i2.getDate());
       } else if ("id".equals(index)) {
         comp = (Instance i1, Instance i2)
-          -> cmp(i1.getId(), i2.getId(), fReverse);
+          -> cmp(i1.getId(), i2.getId());
       } else {
         throw (new IllegalArgumentException("unsupported sort index " + index));
       }
+      if(isReverse(s.getModifiers())){
+        comp = comp.reversed();
+      }
     }
     return comp;
+  }
+
+  private static boolean isReverse(List<Modifier> mods) {
+    return mods.stream().anyMatch(modifier -> modifier.getType().startsWith("desc"));
   }
 }

--- a/src/main/java/org/folio/codex/InstanceComparator.java
+++ b/src/main/java/org/folio/codex/InstanceComparator.java
@@ -22,6 +22,9 @@ public class InstanceComparator {
   }
 
   static Comparator<Instance> get(CQLSortNode sn) {
+    if (sn == null) {
+      return null;
+    }
     Comparator<Instance> comp = null;
     Iterator<ModifierSet> it = sn.getSortIndexes().iterator();
     if (it.hasNext()) {

--- a/src/main/java/org/folio/codex/Multiplexer.java
+++ b/src/main/java/org/folio/codex/Multiplexer.java
@@ -86,7 +86,7 @@ public class Multiplexer implements CodexInstances {
 
   private OkapiClient okapiClient = new OkapiClient();
 
-  @SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S00107"})
+  @SuppressWarnings({"squid:S00107"})
   private <T> void getByQuery(String module, MergeRequest<T> mq, String query,
                                  int offset, int limit, CodexInterfaces codexInterface,
                                  Function<String, CollectionExtension<T>> parser, Handler<AsyncResult<Void>> fut) {

--- a/src/main/java/org/folio/codex/Multiplexer.java
+++ b/src/main/java/org/folio/codex/Multiplexer.java
@@ -46,6 +46,7 @@ import org.folio.rest.jaxrs.resource.CodexInstances;
 public class Multiplexer implements CodexInstances {
 
   private static final String CODEX_INSTANCES_QUERY = "/codex-instances?";
+  private static final String CODEX_PACKAGES_QUERY = "/codex-packages?";
 
   static class MergeRequest<T> {
     int offset;
@@ -66,9 +67,6 @@ public class Multiplexer implements CodexInstances {
   static class CollectionExtension<T> {
     private ResultInfo resultInfo;
     private List<T> items;
-
-    public CollectionExtension() {
-    }
 
     public ResultInfo getResultInfo() {
       return resultInfo;
@@ -91,12 +89,13 @@ public class Multiplexer implements CodexInstances {
 
   private OkapiClient okapiClient = new OkapiClient();
 
+  @SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S00107"})
   private <T> void getByQuery(String module, MergeRequest<T> mq, String query,
                                  int offset, int limit, CodexInterfaces codexInterface,
                                  Function<String, CollectionExtension<T>> parser, Handler<AsyncResult<Void>> fut) {
 
     HttpClient client = mq.vertxContext.owner().createHttpClient();
-    String queryPath = codexInterface.equals(CodexInterfaces.CODEX) ? CODEX_INSTANCES_QUERY : CODEX_INSTANCES_QUERY;
+    String queryPath = codexInterface.equals(CodexInterfaces.CODEX) ? CODEX_INSTANCES_QUERY : CODEX_PACKAGES_QUERY;
 
     String url = mq.headers.get(XOkapiHeaders.URL) + queryPath
     + "offset=" + offset + "&limit=" + limit;

--- a/src/main/java/org/folio/codex/Multiplexer.java
+++ b/src/main/java/org/folio/codex/Multiplexer.java
@@ -43,31 +43,62 @@ import org.folio.rest.jaxrs.resource.CodexInstances;
 @java.lang.SuppressWarnings({"squid:S1192"})
 public class Multiplexer implements CodexInstances {
 
-  static class MergeRequest {
+  private static final String CODEX_INSTANCES_QUERY = "/codex-instances?";
+  private static final String CODEX_PACKAGES_QUERY = "/codex-packages?";
+
+  static class MergeRequest<T, K> {
     int offset;
     int limit;
     Map<String, String> headers;
     Context vertxContext;
-    Map<String, MuxCollection> cols;
+    Map<String, MuxCollection<T, K>> cols;
   }
 
-  public static class MuxCollection {
+  public static class MuxCollection<T, K> {
     int statusCode;
     Buffer message;
-    InstanceCollection col;
+    K col;
+    CollectionExtension<T> colExt;
     String query;
+  }
+
+
+  class CollectionExtension<T> {
+    private ResultInfo resultInfo;
+    private List<T> items;
+
+    public CollectionExtension() {
+    }
+
+    public ResultInfo getResultInfo() {
+      return resultInfo;
+    }
+
+    public void setResultInfo(ResultInfo resultInfo) {
+      this.resultInfo = resultInfo;
+    }
+
+    public List<T> getItems() {
+      return items;
+    }
+
+    public void setItems(List<T> items) {
+      this.items = items;
+    }
   }
 
   private static Logger logger = LoggerFactory.getLogger("codex.mux");
 
   private OkapiClient okapiClient = new OkapiClient();
 
-  private void getByQuery(String module, MergeRequest mq, String query,
-    int offset, int limit, Handler<AsyncResult<Void>> fut) {
+  private <T, K> void getByQuery(String module, MergeRequest<T, K> mq, String query,
+    int offset, int limit, CodexInterfaces codexInterface, Class<K> clazz, Handler<AsyncResult<Void>> fut) {
 
     HttpClient client = mq.vertxContext.owner().createHttpClient();
-    String url = mq.headers.get(XOkapiHeaders.URL) + "/codex-instances?"
-      + "offset=" + offset + "&limit=" + limit;
+    String queryPath = codexInterface.equals(CodexInterfaces.CODEX) ? CODEX_INSTANCES_QUERY : CODEX_INSTANCES_QUERY;
+
+    String url = mq.headers.get(XOkapiHeaders.URL) + queryPath
+    + "offset=" + offset + "&limit=" + limit;
     try {
       if (query != null) {
         url += "&query=" + URLEncoder.encode(query, "UTF-8");
@@ -77,12 +108,12 @@ public class Multiplexer implements CodexInstances {
       return;
     }
     logger.info("getByQuery url=" + url);
-    okapiClient.getUrl(module, url, client, mq.headers, res -> {
+    okapiClient.<T, K>getUrl(module, url, client, mq.headers, res -> {
       if (res.failed()) {
         logger.warn("getByQuery. getUrl failed " + res.cause());
         fut.handle(Future.failedFuture(res.cause()));
       } else {
-        MuxCollection mc = res.result();
+        MuxCollection<T, K> mc = res.result();
         if (mc.statusCode == 200) {
           try {
             JsonObject j = new JsonObject(mc.message.toString());
@@ -93,7 +124,7 @@ public class Multiplexer implements CodexInstances {
               ri.put("diagnostics", new JsonArray());
               j.put("resultInfo", ri);
             }
-            mc.col = Json.decodeValue(j.encode(), InstanceCollection.class);
+            mc.col = Json.decodeValue(j.encode(), clazz);
             mc.query = query;
           } catch (Exception e) {
             fut.handle(Future.failedFuture(e));
@@ -106,20 +137,20 @@ public class Multiplexer implements CodexInstances {
     });
   }
 
-  private void mergeSort(List<String> modules, CQLNode top, MergeRequest mq,
-    Comparator<Instance> comp, Handler<AsyncResult<InstanceCollection>> handler) {
+  private <T, K> void mergeSort(List<String> modules, CQLNode top, MergeRequest<T, K> mq,
+    Comparator<T> comp, CodexInterfaces codexInterface, Class<K> clazz, Handler<AsyncResult<CollectionExtension<T>>> handler) {
 
     List<Future> futures = new LinkedList<>();
     for (String module : modules) {
       if (top == null) {
         Future fut = Future.future();
-        getByQuery(module, mq, null, 0, mq.offset + mq.limit, fut);
+        getByQuery(module, mq, null, 0, mq.offset + mq.limit, codexInterface, clazz, fut);
         futures.add(fut);
       } else {
         CQLNode node = filterSource(module, top);
         if (node != null) {
           Future fut = Future.future();
-          getByQuery(module, mq, node.toCQL(), 0, mq.offset + mq.limit, fut);
+          getByQuery(module, mq, node.toCQL(), 0, mq.offset + mq.limit, codexInterface, clazz, fut);
           futures.add(fut);
         }
       }
@@ -128,19 +159,19 @@ public class Multiplexer implements CodexInstances {
       if (res2.failed()) {
         handler.handle(Future.failedFuture(res2.cause()));
       } else {
-        InstanceCollection colR = mergeSet2(mq, comp);
-        handler.handle(Future.succeededFuture(colR));
+        CollectionExtension colExt = mergeSet2(mq, comp, codexInterface, clazz );
+        handler.handle(Future.succeededFuture(colExt));
       }
     });
   }
 
-  private ResultInfo createResultInfo(Map<String, MuxCollection> cols) {
+  private <T, K> ResultInfo createResultInfo(Map<String, MuxCollection<T, K>> cols) {
     int totalRecords = 0;
     List<Diagnostic> diagnostics = new LinkedList<>();
     for (MuxCollection col : cols.values()) {
-      if (col.col != null && col.col.getResultInfo() != null) {
-        totalRecords += col.col.getResultInfo().getTotalRecords();
-        diagnostics.addAll(col.col.getResultInfo().getDiagnostics());
+      if (col.colExt != null && col.colExt.getResultInfo() != null) {
+        totalRecords += col.colExt.getResultInfo().getTotalRecords();
+        diagnostics.addAll(col.colExt.getResultInfo().getDiagnostics());
       }
     }
     ResultInfo resultInfo = new ResultInfo().withTotalRecords(totalRecords);
@@ -148,44 +179,43 @@ public class Multiplexer implements CodexInstances {
     return resultInfo;
   }
 
-  private InstanceCollection mergeSet2(MergeRequest mq, Comparator<Instance> comp) {
+  private <T, K> CollectionExtension<T> mergeSet2(MergeRequest<T, K> mq, Comparator<T> comp, CodexInterfaces codexInterface, Class<K> clazz) {
 
-    InstanceCollection colR = new InstanceCollection();
-    colR.setResultInfo(createResultInfo(mq.cols));
+    CollectionExtension<T> collectionExtension = new CollectionExtension<>();
+    collectionExtension.setResultInfo(createResultInfo(mq.cols));
     int[] ptrs = new int[mq.cols.size()]; // all 0
     for (int gOffset = 0; gOffset < mq.offset + mq.limit; gOffset++) {
-      Instance minInstance = null;
+      T minElement = null;
       int minI = -1;
       int i = 0;
       for (MuxCollection col : mq.cols.values()) {
         int idx = ptrs[i];
-        if (col.col != null) {
-          List<Instance> instances = col.col.getInstances();
-          if (idx < instances.size()) {
-            Instance instance = instances.get(idx);
-            if (minInstance == null
+        if (col.colExt != null) {
+          List<T> elements = col.colExt.getItems();
+          if (idx < elements.size()) {
+            T element = elements.get(idx);
+            if (minElement == null
               || (comp == null && ptrs[minI] > ptrs[i])
-              || (comp != null && comp.compare(minInstance, instance) > 0)) {
+              || (comp != null && comp.compare(minElement, element) > 0)) {
               minI = i;
-              minInstance = instance;
+              minElement = element;
             }
           }
         }
         i++;
       }
-      if (minInstance == null) {
+      if (minElement == null) {
         break;
       }
       ptrs[minI]++;
       if (gOffset >= mq.offset) {
-        colR.getInstances().add(minInstance);
+        collectionExtension.getItems().add(minElement);
       }
     }
-    return colR;
+    return collectionExtension;
   }
 
-  void analyzeResult(Map<String, MuxCollection> cols, InstanceCollection res,
-    Handler<AsyncResult<Response>> handler) {
+  private <T> void analyzeResult(Map<String, MuxCollection> cols, CollectionExtension<T> res) {
 
     List<Diagnostic> dl = new LinkedList<>();
     for (Map.Entry<String, MuxCollection> ent : cols.entrySet()) {
@@ -194,7 +224,7 @@ public class Multiplexer implements CodexInstances {
       d.setSource(ent.getKey());
       d.setCode(Integer.toString(mc.statusCode));
       if (mc.col != null) {
-        d.setRecordCount(mc.col.getResultInfo().getTotalRecords());
+        d.setRecordCount(mc.colExt.getResultInfo().getTotalRecords());
       }
       d.setQuery(mc.query);
       if (mc.statusCode != 200) {
@@ -207,8 +237,6 @@ public class Multiplexer implements CodexInstances {
       ResultInfo ri = res.getResultInfo();
       ri.setDiagnostics(dl);
       res.setResultInfo(ri);
-      handler.handle(Future.succeededFuture(
-        CodexInstances.GetCodexInstancesResponse.respond200WithApplicationJson(res)));
   }
 
   private CQLNode filterSource(String mod, CQLNode top) {
@@ -279,19 +307,21 @@ public class Multiplexer implements CodexInstances {
             }
           }
         }
-        MergeRequest mq = new MergeRequest();
+        MergeRequest<Instance, InstanceCollection> mq = new MergeRequest<>();
         mq.cols = new LinkedHashMap<>();
         mq.offset = offset;
         mq.limit = limit;
         mq.vertxContext = vertxContext;
         mq.headers = okapiHeaders;
-        mergeSort(res.result(), top, mq, comp, res2 -> {
+        mergeSort(res.result(), top, mq, comp, CodexInterfaces.CODEX, InstanceCollection.class, res2 -> {
           if (res2.failed()) {
             handler.handle(Future.succeededFuture(
               CodexInstances.GetCodexInstancesResponse.respond500WithTextPlain(res2.cause().getMessage()))
             );
           } else {
-            analyzeResult(mq.cols, res2.result(), handler);
+            //analyzeResult(mq.cols, res2.result());
+            //handler.handle(Future.succeededFuture(
+              //CodexInstances.GetCodexInstancesResponse.respond200WithApplicationJson(res)));
           }
         });
       }

--- a/src/main/java/org/folio/codex/Multiplexer.java
+++ b/src/main/java/org/folio/codex/Multiplexer.java
@@ -256,6 +256,8 @@ public class Multiplexer implements CodexInstances {
       source = new CQLTermNode("source", rel, "kb");
     } else if (mod.startsWith("mod-codex-inventory")) {
       source = new CQLTermNode("source", rel, "local");
+    } else if (mod.startsWith("mod-agreements")) {
+      source = new CQLTermNode("source", rel, "localkb");
     } else if (mod.startsWith("mock")) { // for Unit testing
       source = new CQLTermNode("source", rel, mod);
     }

--- a/src/main/java/org/folio/codex/Multiplexer.java
+++ b/src/main/java/org/folio/codex/Multiplexer.java
@@ -286,9 +286,7 @@ public class Multiplexer implements CodexInstances {
           try {
             top = parser.parse(query);
             CQLSortNode sn = CQLInspect.getSort(top);
-            if (sn != null) {
-              comp = InstanceComparator.get(sn);
-            }
+            comp = InstanceComparator.get(sn);
           } catch (CQLParseException | IllegalArgumentException ex) {
             logger.warn("CQLParseException: " + ex.getMessage());
             handler.handle(

--- a/src/main/java/org/folio/codex/Multiplexer.java
+++ b/src/main/java/org/folio/codex/Multiplexer.java
@@ -45,9 +45,6 @@ import org.folio.rest.jaxrs.resource.CodexInstances;
 @java.lang.SuppressWarnings({"squid:S1192"})
 public class Multiplexer implements CodexInstances {
 
-  private static final String CODEX_INSTANCES_QUERY = "/codex-instances?";
-  private static final String CODEX_PACKAGES_QUERY = "/codex-packages?";
-
   static class MergeRequest<T> {
     int offset;
     int limit;
@@ -95,9 +92,8 @@ public class Multiplexer implements CodexInstances {
                                  Function<String, CollectionExtension<T>> parser, Handler<AsyncResult<Void>> fut) {
 
     HttpClient client = mq.vertxContext.owner().createHttpClient();
-    String queryPath = codexInterface.equals(CodexInterfaces.CODEX) ? CODEX_INSTANCES_QUERY : CODEX_PACKAGES_QUERY;
 
-    String url = mq.headers.get(XOkapiHeaders.URL) + queryPath
+    String url = mq.headers.get(XOkapiHeaders.URL) + codexInterface.getQueryPath()
     + "offset=" + offset + "&limit=" + limit;
     try {
       if (query != null) {

--- a/src/main/java/org/folio/codex/Multiplexer.java
+++ b/src/main/java/org/folio/codex/Multiplexer.java
@@ -285,7 +285,11 @@ public class Multiplexer implements CodexInstances {
           CQLParser parser = new CQLParser(CQLParser.V1POINT2);
           try {
             top = parser.parse(query);
-          } catch (CQLParseException ex) {
+            CQLSortNode sn = CQLInspect.getSort(top);
+            if (sn != null) {
+              comp = InstanceComparator.get(sn);
+            }
+          } catch (CQLParseException | IllegalArgumentException ex) {
             logger.warn("CQLParseException: " + ex.getMessage());
             handler.handle(
               Future.succeededFuture(CodexInstances.GetCodexInstancesResponse.respond400WithTextPlain(ex.getMessage())));
@@ -294,17 +298,6 @@ public class Multiplexer implements CodexInstances {
             handler.handle(
               Future.succeededFuture(CodexInstances.GetCodexInstancesResponse.respond500WithTextPlain(ex.getMessage())));
             return;
-          }
-          CQLSortNode sn = CQLInspect.getSort(top);
-          if (sn != null) {
-            try {
-              comp = InstanceComparator.get(sn);
-            } catch (IllegalArgumentException ex) {
-              handler.handle(
-                Future.succeededFuture(
-                  CodexInstances.GetCodexInstancesResponse.respond400WithTextPlain(ex.getMessage())));
-              return;
-            }
           }
         }
         MergeRequest<Instance> mq = new MergeRequest<>();

--- a/src/main/java/org/folio/codex/OkapiClient.java
+++ b/src/main/java/org/folio/codex/OkapiClient.java
@@ -80,15 +80,15 @@ public class OkapiClient {
     return future;
   }
 
-  public void getUrl(String module, String url, HttpClient client, Map<String, String> okapiHeaders,
-                     Handler<AsyncResult<Multiplexer.MuxCollection>> fut) {
+  public <T, K> void getUrl(String module, String url, HttpClient client,
+                      Map<String, String> okapiHeaders, Handler<AsyncResult<Multiplexer.MuxCollection<T, K>>> fut) {
 
     HttpClientRequest req = client.getAbs(url, res -> {
       Buffer b = Buffer.buffer();
       res.handler(b::appendBuffer);
       res.endHandler(r -> {
         client.close();
-        Multiplexer.MuxCollection mc = new Multiplexer.MuxCollection();
+        Multiplexer.MuxCollection<T, K> mc = new Multiplexer.MuxCollection<T, K>();
         mc.message = b;
         mc.statusCode = res.statusCode();
         fut.handle(Future.succeededFuture(mc));

--- a/src/main/java/org/folio/codex/OkapiClient.java
+++ b/src/main/java/org/folio/codex/OkapiClient.java
@@ -80,15 +80,15 @@ public class OkapiClient {
     return future;
   }
 
-  public <T, K> void getUrl(String module, String url, HttpClient client,
-                      Map<String, String> okapiHeaders, Handler<AsyncResult<Multiplexer.MuxCollection<T, K>>> fut) {
+  public <T> void getUrl(String module, String url, HttpClient client,
+                      Map<String, String> okapiHeaders, Handler<AsyncResult<Multiplexer.MuxCollection<T>>> fut) {
 
     HttpClientRequest req = client.getAbs(url, res -> {
       Buffer b = Buffer.buffer();
       res.handler(b::appendBuffer);
       res.endHandler(r -> {
         client.close();
-        Multiplexer.MuxCollection<T, K> mc = new Multiplexer.MuxCollection<T, K>();
+        Multiplexer.MuxCollection<T> mc = new Multiplexer.MuxCollection<>();
         mc.message = b;
         mc.statusCode = res.statusCode();
         fut.handle(Future.succeededFuture(mc));

--- a/src/main/java/org/folio/rest/impl/CodexMuxImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexMuxImpl.java
@@ -2,7 +2,6 @@ package org.folio.rest.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -13,10 +12,8 @@ import org.folio.codex.Mock;
 import org.folio.codex.Multiplexer;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.resource.CodexInstances;
-import org.folio.rest.jaxrs.resource.CodexPackages;
-import org.folio.rest.jaxrs.resource.CodexPackagesSources;
 
-public class CodexMuxImpl implements CodexInstances, CodexPackages, CodexPackagesSources {
+public class CodexMuxImpl implements CodexInstances {
 
   private static CodexInstances mux;
   private static Map<String, CodexInstances> mock = new HashMap<>();
@@ -55,21 +52,6 @@ public class CodexMuxImpl implements CodexInstances, CodexPackages, CodexPackage
 
     get(okapiHeaders).getCodexInstancesById(id, lang,
       okapiHeaders, asyncResultHandler, vertxContext);
-  }
-
-  @Override
-  public void getCodexPackages(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
-  }
-
-  @Override
-  public void getCodexPackagesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
-  }
-
-  @Override
-  public void getCodexPackagesSources(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
   }
 
 }

--- a/src/main/java/org/folio/rest/impl/CodexMuxImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexMuxImpl.java
@@ -2,6 +2,7 @@ package org.folio.rest.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -12,8 +13,10 @@ import org.folio.codex.Mock;
 import org.folio.codex.Multiplexer;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.resource.CodexInstances;
+import org.folio.rest.jaxrs.resource.CodexPackages;
+import org.folio.rest.jaxrs.resource.CodexPackagesSources;
 
-public class CodexMuxImpl implements CodexInstances {
+public class CodexMuxImpl implements CodexInstances, CodexPackages, CodexPackagesSources {
 
   private static CodexInstances mux;
   private static Map<String, CodexInstances> mock = new HashMap<>();
@@ -52,6 +55,21 @@ public class CodexMuxImpl implements CodexInstances {
 
     get(okapiHeaders).getCodexInstancesById(id, lang,
       okapiHeaders, asyncResultHandler, vertxContext);
+  }
+
+  @Override
+  public void getCodexPackages(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+
+  @Override
+  public void getCodexPackagesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+
+  @Override
+  public void getCodexPackagesSources(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(Response.status(Response.Status.NOT_IMPLEMENTED).build()));
   }
 
 }


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/MODCXMUX-31 -- Code currently handles merge and sort for instance types. We are updating code to handle new types (to start with package type). 

## Approach
- Began with changes made as part of https://github.com/folio-org/mod-codex-mux/pull/49
- Using parameterized classes for MergeRequest and MuxCollection and impacted methods
- Added CollectionExtension class as an attempt to generically access ResultInfo and List<T> -- common elements found in InstanceCollection and PackageCollection
- Incorporated suggestion of only using CollectionExtension<T> during merge and sort (avoid multiple parameters)
-  Included function that parses response  

#### TODOS and Open Questions

[ ] - Suggestions or a better approach?
[ ] - Code Complexity 
[ ] - Need to add a separate comparator for packages (name sort only)


## Learning



