### PR TITLE
MODCXMUX-42 Make mux to be default module for codex-packages endpoints

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -20,7 +20,6 @@
     {
       "id" : "codex-packages",
       "version" : "1.0",
-      "interfaceType": "multiple",
       "handlers" : [
         {
           "methods" : [ "GET" ],


### PR DESCRIPTION
## Purpose
Make mod-codex-mux to be called when request is missing X-Okapi-Module-Id
## Approach
Remove "interfaceType":"multiple" line from endpoint declaration
