### PR TITLE
Release 2.5.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2.5.0 2019-03-19
+ * MODCXMUX-47 - Fix failing API Tests - Updated path for downloaded schemas
+
 ## 2.4.0 2019-03-14
  * MODCXMUX-30 - Create common RAML definition for Packages endpoint
  * MODCXMUX-31 Update Merge And Sort Code to handle added Package Type

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-codex-mux</artifactId>
-  <version>2.5.0-SNAPSHOT</version>
+  <version>2.5.0</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -56,7 +56,7 @@
     <url>https://github.com/folio-org/mod-codex-mux</url>
     <connection>scm:git:git://github.com/folio-org/mod-codex-mux</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-codex-mux.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.5.0</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-codex-mux</artifactId>
-  <version>2.5.0</version>
+  <version>2.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -56,7 +56,7 @@
     <url>https://github.com/folio-org/mod-codex-mux</url>
     <connection>scm:git:git://github.com/folio-org/mod-codex-mux</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-codex-mux.git</developerConnection>
-    <tag>v2.5.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>


### PR DESCRIPTION
## Purpose
Create release which resolves API test issues . 

Specifically api tests were failing due to similarly named schemas and adjustment has been made to specify path for Codex schema

https://github.com/folio-org/mod-codex-ekb/pull/98

*  https://issues.folio.org/browse/MODCXMUX-47 

## Approach
- Follow documented release procedure for mvn module