### PR TITLE
MODCXMUX-37 - Create RAML for GET codex-instances-sources

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "provides": [
     {
       "id": "codex",
-      "version": "3.2",
+      "version": "3.3",
       "handlers": [
         {
           "methods": ["GET"],
@@ -14,6 +14,10 @@
         {
           "methods": ["GET"],
           "pathPattern": "/codex-instances/{id}"
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/codex-instances-sources"
         }
       ]
     },
@@ -27,8 +31,7 @@
         }, {
           "methods" : [ "GET" ],
           "pathPattern" : "/codex-packages/{id}"
-        },
-        {
+        }, {
           "methods": ["GET"],
           "pathPattern": "/codex-packages-sources"
         }

--- a/src/main/java/org/folio/rest/impl/CodexInstancesSourcesImpl.java
+++ b/src/main/java/org/folio/rest/impl/CodexInstancesSourcesImpl.java
@@ -1,0 +1,22 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+import org.folio.rest.jaxrs.resource.CodexInstancesSources;
+
+public class CodexInstancesSourcesImpl implements CodexInstancesSources {
+  @Override
+  public void getCodexInstancesSources(String lang, Map<String, String> okapiHeaders,
+                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    asyncResultHandler.handle(Future.succeededFuture(
+      GetCodexInstancesSourcesResponse.status(Response.Status.NOT_IMPLEMENTED).build()));
+  }
+}

--- a/src/test/java/org/folio/codex/CodexInstancesSourcesImplTest.java
+++ b/src/test/java/org/folio/codex/CodexInstancesSourcesImplTest.java
@@ -1,0 +1,73 @@
+package org.folio.codex;
+
+import static org.junit.Assert.assertEquals;
+
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Header;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.tools.utils.NetworkUtils;
+
+@RunWith(VertxUnitRunner.class)
+public class CodexInstancesSourcesImplTest {
+
+  private static final String CODEX_INSTANCES_SOURCES_PATH = "/codex-instances-sources";
+  private final String TENANT = "testlib";
+  @Rule
+  public WireMockRule userMockServer = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort().notifier(
+      new Slf4jNotifier(true)));
+
+  private int portCodex = NetworkUtils.nextFreePort();
+
+  private Vertx vertx = Vertx.vertx();
+
+  private Header tenantHeader = new Header(XOkapiHeaders.TENANT, TENANT);
+  private Header urlHeader;
+
+  @Before
+  public void setUp(TestContext context) {
+    urlHeader = new Header(XOkapiHeaders.URL, getUrl());
+    setupMux(context);
+  }
+
+  private String getUrl() {
+    int port = userMockServer.port();
+    return "http://localhost:" + port;
+  }
+
+  private void setupMux(TestContext context) {
+    JsonObject conf = new JsonObject();
+    conf.put("http.port", portCodex);
+    DeploymentOptions opt = new DeploymentOptions().setConfig(conf);
+    vertx.deployVerticle(RestVerticle.class.getName(), opt, context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void shouldReturn501WhenEndpointNotImplemented() {
+
+    int statusCode = RestAssured.given()
+      .port(portCodex)
+      .header(tenantHeader)
+      .header(urlHeader)
+      .get(CODEX_INSTANCES_SOURCES_PATH)
+      .then()
+      .log()
+      .ifValidationFails()
+      .extract().statusCode();
+
+    assertEquals(501, statusCode);
+  }
+}


### PR DESCRIPTION
## Purpose
Due to https://issues.folio.org/browse/MODCXMUX-37 we are expecting to add an additional endpoint 
`/codex-instances-sources` to be able to get information about instances sources similarly to https://github.com/folio-org/mod-codex-mux/pull/47

## Approach
* updated `raml1.0` branch to be able to use `codex-instances-sources.raml`, added in scope of #https://github.com/folio-org/raml/pull/119
* modified ModuleDescriptor file to include `/codex-instances-sources` endpoint
* added sample implementation of `/codex-instances-sources` and test to pass SonarQube quality gate

#### TODOS and Open Questions
- [ ] Define wheather `/codex-instances-sources` endpoint should be added to an existing `codex` interface or should be a treated as a separate interface