### PR TITLE
MODCXMUX-55: Add required permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,15 +9,18 @@
       "handlers": [
         {
           "methods": ["GET"],
-          "pathPattern": "/codex-instances"
+          "pathPattern": "/codex-instances",
+          "permissionsRequired": ["codex-mux.instances.collection.get"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/codex-instances/{id}"
+          "pathPattern": "/codex-instances/{id}",
+          "permissionsRequired": ["codex-mux.instances.item.get"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/codex-instances-sources"
+          "pathPattern": "/codex-instances-sources",
+          "permissionsRequired": ["codex-mux.instances-sources.collection.get"]
         }
       ]
     },
@@ -27,13 +30,16 @@
       "handlers" : [
         {
           "methods" : [ "GET" ],
-          "pathPattern" : "/codex-packages"
+          "pathPattern" : "/codex-packages",
+          "permissionsRequired": ["codex-mux.packages.collection.get"]
         }, {
           "methods" : [ "GET" ],
-          "pathPattern" : "/codex-packages/{id}"
+          "pathPattern" : "/codex-packages/{id}",
+          "permissionsRequired": ["codex-mux.packages.item.get"]
         }, {
           "methods": ["GET"],
-          "pathPattern": "/codex-packages-sources"
+          "pathPattern": "/codex-packages-sources",
+          "permissionsRequired": ["codex-mux.packages-sources.collection.get"]
         }
       ]
     },
@@ -60,7 +66,51 @@
       ]
     }
   ],
-  "permissionSets": [],
+  "permissionSets": [
+    {
+      "permissionName": "codex-mux.instances.collection.get",
+      "displayName": "get codex instances",
+      "description": "Get codex instances"
+    },
+    {
+      "permissionName": "codex-mux.instances.item.get",
+      "displayName": "get codex instance",
+      "description": "Get codex instance"
+    },
+    {
+      "permissionName": "codex-mux.instances-sources.collection.get",
+      "displayName": "get codex instances sources",
+      "description": "Get codex instances sources"
+    },
+    {
+      "permissionName": "codex-mux.packages.collection.get",
+      "displayName": "get codex packages",
+      "description": "Get codex packages"
+    },
+    {
+      "permissionName": "codex-mux.packages.item.get",
+      "displayName": "get codex package",
+      "description": "Get codex package"
+    },
+    {
+      "permissionName": "codex-mux.packages-sources.collection.get",
+      "displayName": "get codex package sources",
+      "description": "Get codex package sources"
+    },
+    {
+      "permissionName": "codex-mux.all",
+      "displayName": "Codex Multiplexer - all permissions",
+      "description": "All permissions for Codex Multiplexer",
+      "subPermissions": [
+        "codex-mux.instances.collection.get",
+        "codex-mux.instances.item.get",
+        "codex-mux.instances-sources.collection.get",
+        "codex-mux.packages.collection.get",
+        "codex-mux.packages.item.get",
+        "codex-mux.packages-sources.collection.get"
+      ]
+    }
+  ],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerPull": false,

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -10,17 +10,20 @@
         {
           "methods": ["GET"],
           "pathPattern": "/codex-instances",
-          "permissionsRequired": ["codex-mux.instances.collection.get"]
+          "permissionsRequired": ["codex-mux.instances.collection.get"],
+          "modulePermissions": ["codex-ekb.instances.collection.get"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/codex-instances/{id}",
-          "permissionsRequired": ["codex-mux.instances.item.get"]
+          "permissionsRequired": ["codex-mux.instances.item.get"],
+          "modulePermissions": ["codex-ekb.instances.item.get"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/codex-instances-sources",
-          "permissionsRequired": ["codex-mux.instances-sources.collection.get"]
+          "permissionsRequired": ["codex-mux.instances-sources.collection.get"],
+          "modulePermissions": ["codex-ekb.instances-sources.collection.get"]
         }
       ]
     },
@@ -31,15 +34,18 @@
         {
           "methods" : [ "GET" ],
           "pathPattern" : "/codex-packages",
-          "permissionsRequired": ["codex-mux.packages.collection.get"]
+          "permissionsRequired": ["codex-mux.packages.collection.get"],
+          "modulePermissions": ["codex-ekb.packages.collection.get"]
         }, {
           "methods" : [ "GET" ],
           "pathPattern" : "/codex-packages/{id}",
-          "permissionsRequired": ["codex-mux.packages.item.get"]
+          "permissionsRequired": ["codex-mux.packages.item.get"],
+          "modulePermissions": ["codex-ekb.packages.item.get"]
         }, {
           "methods": ["GET"],
           "pathPattern": "/codex-packages-sources",
-          "permissionsRequired": ["codex-mux.packages-sources.collection.get"]
+          "permissionsRequired": ["codex-mux.packages-sources.collection.get"],
+          "modulePermissions": ["codex-ekb.packages-sources.collection.get"]
         }
       ]
     },


### PR DESCRIPTION
## Purpose
Add required permission so that mod-codex-mux can't be called without logging in.

## Approach
Add permissions with prefix codex-mux.*

## Learning
Even though mod-codex-mux and mod-codex-ekb share the same interface they need to have permissions with different names, otherwise permissions will override each other. Permissions are also implementation specific (i.e. different implementations need to call different modules, so they need different "modulePermissions" sections)

It seems that after permissions are added to mod-codex-ekb, we will need to add "modulePermissions" section to mod-codex-mux, because mod-codex-mux needs to call mod-codex-ekb