### PR TITLE
MODCXMUX-54: Update jackson to 2.10.1 to fix jackson-databind security.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,6 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls/raml-util/ramls/codex</ramlfiles_path>
     <jsonschema_paths>raml-util/schemas,raml-util/schemas/codex</jsonschema_paths>
-    <vertx-version>3.5.4</vertx-version>
-    <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.9.1</jackson-databind.version>
     <rest.assured.version>2.8.0</rest.assured.version>
   </properties>
 
@@ -103,12 +100,10 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx-version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>${vertx-version}</version>
     </dependency>
     <dependency>
       <groupId>org.z3950.zing</groupId>
@@ -118,7 +113,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -128,19 +122,27 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson-databind.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.10.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.5.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>net.sf.jopt-simple</groupId>
         <artifactId>jopt-simple</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.10.0</version>
+        <version>2.10.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
The update fixes two polymorphic typing issues that are security vulnerabilities:
* https://nvd.nist.gov/vuln/detail/CVE-2019-16335
* https://nvd.nist.gov/vuln/detail/CVE-2019-14540

This also reduces the number of pom.xml `<dependencies>` by using
`<dependencyManagement>` BOMs for jackson and vertx.