### PR TITLE
MODCXMUX-85: Upgrade deps fixing DoS and HTTP Request Smuggling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,10 @@
     <ramlfiles_path>${basedir}/ramls/raml-util/ramls/codex</ramlfiles_path>
     <jsonschema_paths>raml-util/schemas,raml-util/schemas/codex</jsonschema_paths>
 
-    <domain-models-runtime.version>33.0.0</domain-models-runtime.version>
-    <folio-service-tools.version>1.7.0</folio-service-tools.version>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <domain-models-runtime.version>33.2.9</domain-models-runtime.version>
+    <folio-service-tools.version>1.8.0</folio-service-tools.version>
+    <vertx.version>4.2.7</vertx.version>
     <cql-java.version>1.13</cql-java.version>
-    <jackson.version>2.12.1</jackson.version>
 
     <junit.version>4.13.2</junit.version>
     <wiremock.version>2.27.2</wiremock.version>
@@ -143,23 +142,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${jackson.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>${vertx.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vert.x from 4.1.0.CR1 to 4.2.7 fixing many bugs. This also indirectly upgrades netty-codec-http from 4.1.65.Final to 4.1.74.Final fixing HTTP Request Smuggling https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-43797

Upgrade log4j from 2.16.0 to 2.17.2 fixing Denial of Service (DoS) https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-45105

Upgrade RMB from 33.0.0 to 33.2.9 fixing many bugs.

Upgrade folio-service-tools from 1.7.0 to 1.8.0.