### PR TITLE
Prepare 2.12.0 development iteration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2.11.2 2022-06-28
+* MODCXMUX-85: Upgrade deps fixing DoS and HTTP Request Smuggling
 * MODCXMUX-88 Upgrade mod-codex-mux to RMB 34.0.0 and Vert.x 4.3.1
 
 ## 2.11.1 2021-12-16

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 2.11.2 2022-06-28
-* MODCXMUX-85: Upgrade deps fixing DoS and HTTP Request Smuggling
+* MODCXMUX-85 Upgrade deps fixing DoS and HTTP Request Smuggling
 * MODCXMUX-88 Upgrade mod-codex-mux to RMB 34.0.0 and Vert.x 4.3.1
 
 ## 2.11.1 2021-12-16

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 2.11.2-SNAPSHOT xxxx-xx-xx
+## 2.11.2 2022-06-28
 * MODCXMUX-88 Upgrade mod-codex-mux to RMB 34.0.0 and Vert.x 4.3.1
 
 ## 2.11.1 2021-12-16

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-codex-mux</artifactId>
-  <version>2.11.2-SNAPSHOT</version>
+  <version>2.12.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -88,7 +88,7 @@
     <url>https://github.com/folio-org/mod-codex-mux</url>
     <connection>scm:git:git://github.com/folio-org/mod-codex-mux</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-codex-mux.git</developerConnection>
-    <tag>release/v2.11</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <url>https://github.com/folio-org/mod-codex-mux</url>
     <connection>scm:git:git://github.com/folio-org/mod-codex-mux</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-codex-mux.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>release/v2.11</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <jsonschema_paths>raml-util/schemas,raml-util/schemas/codex</jsonschema_paths>
 
     <domain-models-runtime.version>34.0.0</domain-models-runtime.version>
-    <folio-service-tools.version>1.9.0-SNAPSHOT</folio-service-tools.version>
+    <folio-service-tools.version>1.9.0</folio-service-tools.version>
     <vertx.version>4.3.1</vertx.version>
     <cql-java.version>1.13</cql-java.version>
 


### PR DESCRIPTION
- Update `folio-service-tools` to latest release version (not SNAPSHOT)
- Prepare to the next development iteration